### PR TITLE
Use full subgroup path in token variables

### DIFF
--- a/exporter.json
+++ b/exporter.json
@@ -1,25 +1,21 @@
 {
-    "id": "io.supernova.tailwind",
-    "name": "Tailwind",
-    "description": "Tailwind CSS exporter",
-    "author": "Florian Torres & Ivan Terpugov & Jiri Trecak",
-    "organization": "Ascanio",
-    "homepage": "https://ascan.io",
-    "source_dir": "src",
-    "version": "1.6",
-    "usesBrands": true,
-    "config": {
-        "sources": "sources.json",
-        "output": "output.json",
-        "js": "src/js/helpers.js"
-    },
-    "engines": {
-        "pulsar": "1.0.0",
-        "supernova": "1.0.0"
-    },
-    "tags": [
-        "TailwindCSS",
-        "Tokens",
-        "Styles"
-    ]
+  "id": "io.supernova.tailwind",
+  "name": "Tailwind",
+  "description": "Tailwind CSS exporter",
+  "author": "Florian Torres & Ivan Terpugov & Jiri Trecak",
+  "organization": "Ascanio",
+  "homepage": "https://ascan.io",
+  "source_dir": "src",
+  "version": "1.7",
+  "usesBrands": true,
+  "config": {
+    "sources": "sources.json",
+    "output": "output.json",
+    "js": "src/js/helpers.js"
+  },
+  "engines": {
+    "pulsar": "1.0.0",
+    "supernova": "1.0.0"
+  },
+  "tags": ["TailwindCSS", "Tokens", "Styles"]
 }

--- a/src/js/helpers.js
+++ b/src/js/helpers.js
@@ -7,7 +7,7 @@ Pulsar.registerFunction(
     // Create array with all path segments and token name at the end
     const segments = [...tokenGroup.path];
     if (!tokenGroup.isRoot) {
-      segments.push(tokenGroup.name)
+      segments.push(tokenGroup.name);
     }
     segments.push(token.name);
 
@@ -16,61 +16,86 @@ Pulsar.registerFunction(
     }
 
     // Create "sentence" separated by spaces so we can camelcase it all
-    let sentence = segments.join(" ");
-
-    // camelcase string from all segments
-     sentence = sentence
-      .toLowerCase()
-      .replace(/[^a-zA-Z0-9]+(.)/g, (m, chr) => "-" + chr)
-    
-    // only allow letters, digits, underscore and hyphen
-    sentence = sentence.replace(/[^a-zA-Z0-9_-]/g, '_')
-
-    // prepend underscore if it starts with digit 
-    if (/^\d/.test(sentence)) {
-      sentence = '_' + sentence;
-    }
-
-    return sentence;
+    return cleanSentence(segments.join(" "), true);
   }
 );
 
-function getGroupNameFromOriginName(originName){
-  return originName.substr(0, originName.indexOf('/')).trim().toLowerCase()
+Pulsar.registerFunction("readableGroupName", function (tokenGroup) {
+  // Create array with all path segments and token name at the end
+  const segments = [...tokenGroup.path];
+  if (!tokenGroup.isRoot) {
+    segments.push(tokenGroup.name);
+  }
+
+  // Create "sentence" separated by spaces so we can camelcase it all
+  return cleanSentence(segments.join(" "), false);
+});
+
+Pulsar.registerFunction("cleanString", function (name) {
+  return cleanSentence(name, false);
+});
+
+function cleanSentence(sentence, handleStartingDigits) {
+  sentence = sentence
+    .toLowerCase()
+    .replace(/[^a-zA-Z0-9]+(.)/g, (m, chr) => "-" + chr);
+
+  // only allow letters, digits, underscore and hyphen
+  sentence = sentence.replace(/[^a-zA-Z0-9_-]/g, "_");
+
+  // prepend underscore if it starts with digit
+  if (/^\d/.test(sentence) && handleStartingDigits) {
+    sentence = "_" + sentence;
+  }
+
+  return sentence;
 }
 
-function getGroups(allTokens){
-  let allGroups = allTokens.map(token => getGroupNameFromOriginName(token.origin.name))
-  let uniqueGroups = [...new Set(allGroups)]
-  return uniqueGroups
+function getGroupNameFromOriginName(originName) {
+  return originName.substr(0, originName.indexOf("/")).trim().toLowerCase();
 }
 
-Pulsar.registerFunction("getGroups", getGroups)
+function getGroups(allTokens) {
+  let allGroups = allTokens.map((token) =>
+    getGroupNameFromOriginName(token.origin.name)
+  );
+  let uniqueGroups = [...new Set(allGroups)];
+  return uniqueGroups;
+}
+
+Pulsar.registerFunction("getGroups", getGroups);
 
 function getTokensByGroup(allTokens, group) {
-  return allTokens.filter(token => token.origin.name.substr(0, getGroupNameFromOriginName(token.origin.name) === group))
+  return allTokens.filter((token) =>
+    token.origin.name.substr(
+      0,
+      getGroupNameFromOriginName(token.origin.name) === group
+    )
+  );
 }
 
-Pulsar.registerFunction("getTokensByGroup", getTokensByGroup)
+Pulsar.registerFunction("getTokensByGroup", getTokensByGroup);
 
-function findAliases(token, allTokens){
-  let aliases = allTokens.filter(t => t.value.referencedToken && t.value.referencedToken.id === token.id)
+function findAliases(token, allTokens) {
+  let aliases = allTokens.filter(
+    (t) => t.value.referencedToken && t.value.referencedToken.id === token.id
+  );
   for (const t of aliases) {
-    aliases = aliases.concat(findAliases(t, allTokens))
+    aliases = aliases.concat(findAliases(t, allTokens));
   }
   return aliases;
 }
 
-Pulsar.registerFunction("findAliases", findAliases)
+Pulsar.registerFunction("findAliases", findAliases);
 
-Pulsar.registerFunction("gradientAngle", function(from, to) {
-    var deltaY = (to.y - from.y);
-    var deltaX = (to.x - from.x);
-    var radians = Math.atan2(deltaY, deltaX); 
-    var result = radians * 180 / Math.PI; 
-    result = result + 90; 
-    return  ((result < 0) ? (360 + result) : result) % 360;
-})
+Pulsar.registerFunction("gradientAngle", function (from, to) {
+  var deltaY = to.y - from.y;
+  var deltaX = to.x - from.x;
+  var radians = Math.atan2(deltaY, deltaX);
+  var result = (radians * 180) / Math.PI;
+  result = result + 90;
+  return (result < 0 ? 360 + result : result) % 360;
+});
 
 /**
  * Behavior configuration of the exporter
@@ -85,44 +110,48 @@ Pulsar.registerPayload("behavior", {
   typographyTokenPrefix: "typography",
 });
 
-
-
 /** Describe complex shadow token */
 Pulsar.registerFunction("shadowDescription", function (shadowToken) {
+  let connectedShadow = shadowToken.shadowLayers
+    ?.reverse()
+    .map((shadow) => {
+      return shadowTokenValue(shadow);
+    })
+    .join(", ");
 
-  let connectedShadow = shadowToken.shadowLayers?.reverse().map((shadow) => {
-    return shadowTokenValue(shadow)
-  })
-    .join(", ")
-
-  return connectedShadow
-})
+  return connectedShadow;
+});
 
 /** Convert complex shadow value to CSS representation */
 function shadowTokenValue(shadowToken) {
-  var blurRadius = getValueWithCorrectUnit(nonNegativeValue(shadowToken.value.radius.measure));
+  var blurRadius = getValueWithCorrectUnit(
+    nonNegativeValue(shadowToken.value.radius.measure)
+  );
   var offsetX = getValueWithCorrectUnit(shadowToken.value.x.measure);
   var offsetY = getValueWithCorrectUnit(shadowToken.value.y.measure);
   var spreadRadius = getValueWithCorrectUnit(shadowToken.value.spread.measure);
 
-  return `${shadowToken.value.type === "Inner" ? "inset " : ""}${offsetX} ${offsetY} ${blurRadius} ${spreadRadius} ${getFormattedRGB(shadowToken.value.color)}`
+  return `${
+    shadowToken.value.type === "Inner" ? "inset " : ""
+  }${offsetX} ${offsetY} ${blurRadius} ${spreadRadius} ${getFormattedRGB(
+    shadowToken.value.color
+  )}`;
 }
-
 
 function getValueWithCorrectUnit(value, unit, forceUnit) {
   if (value === 0 && forceUnit !== true) {
-    return `${value}`
+    return `${value}`;
   } else {
     // todo: add support for other units (px, rem, em, etc.)
-    return `${value}px`
+    return `${value}px`;
   }
 }
 
 function nonNegativeValue(num) {
   if (num <= 0) {
-    return 0
+    return 0;
   } else {
-    return num
+    return num;
   }
 }
 
@@ -130,21 +159,21 @@ function nonNegativeValue(num) {
 function measureTypeIntoReadableUnit(type) {
   switch (type) {
     case "Points":
-      return "pt"
+      return "pt";
     case "Pixels":
-      return "px"
+      return "px";
     case "Percent":
-      return "%"
+      return "%";
     case "Ems":
-      return "em"
+      return "em";
   }
 }
 
 function getFormattedRGB(colorValue) {
   if (colorValue.a === 0) {
-    return `rgb(${colorValue.r},${colorValue.g},${colorValue.b})`
+    return `rgb(${colorValue.r},${colorValue.g},${colorValue.b})`;
   } else {
     const opacity = Math.round((colorValue.a / 255) * 100) / 100;
-    return `rgba(${colorValue.r},${colorValue.g},${colorValue.b},${opacity})`
+    return `rgba(${colorValue.r},${colorValue.g},${colorValue.b},${opacity})`;
   }
 }

--- a/src/main-renderers/tailwind-variables.pr
+++ b/src/main-renderers/tailwind-variables.pr
@@ -5,15 +5,15 @@ module.exports = {
     {[ traverse colorGroup property subgroups into subgroup ]}
         {[ if !subgroup.isRoot ]}
         {[ const tokens = ds.tokensByGroupId(subgroup.id) /]}
-            {[ if tokens.length !== 0 ]}
-                '{{ readableGroupName(subgroup)}}': {
-                    {[ for token in tokens ]}
-                        {[ let tokenName = cleanString(token.name) /]}
-                        '{{ ((tokenName === "main") ? "DEFAULT" : tokenName) }}': '{[ inject "rendered-color" context token.value /]}', {[ inject "rendered-description" context token /]}
-                    
-                    {[/]}
-                },
+        {[ if tokens.length !== 0 ]}
+        '{{ readableGroupName(subgroup)}}': {
+            {[ for token in tokens ]}
+                {[ let tokenName = cleanString(token.name) /]}
+                '{{ ((tokenName === "main") ? "DEFAULT" : tokenName) }}': '{[ inject "rendered-color" context token.value /]}', {[ inject "rendered-description" context token /]}
+
             {[/]}
+        },
+        {[/]}
         {[else]}
         {[ const tokens = ds.tokensByGroupId(subgroup.id) /]}
         {[ for token in tokens ]}

--- a/src/main-renderers/tailwind-variables.pr
+++ b/src/main-renderers/tailwind-variables.pr
@@ -4,14 +4,15 @@ module.exports = {
     {[ const colorGroup = ds.tokenGroupTreeByType("Color", brand.id) /]}
     {[ traverse colorGroup property subgroups into subgroup ]}
         {[ if !subgroup.isRoot ]}
-        '{{ subgroup.name.lowercased().replacing(" ", "-") }}': {
         {[ const tokens = ds.tokensByGroupId(subgroup.id) /]}
-        {[ for token in tokens ]}
-            {[ let tokenName = token.name.replacing("$", "").lowercased().replacing(" ", "-") /]}
-            '{{ ((tokenName === "main") ? "DEFAULT" : tokenName) }}': '{[ inject "rendered-color" context token.value /]}', {[ inject "rendered-description" context token /]}
-
-        {[/]}
-        },
+            {[ if tokens.length !== 0 ]}
+                '{{ readableGroupName(subgroup)}}': {
+                    {[ for token in tokens ]}
+                        {[ let tokenName = cleanString(token.name) /]}
+                        '{{ ((tokenName === "main") ? "DEFAULT" : tokenName) }}': '{[ inject "rendered-color" context token.value /]}', {[ inject "rendered-description" context token /]}
+                    {[/]}
+                },
+            {[/]}
         {[else]}
         {[ const tokens = ds.tokensByGroupId(subgroup.id) /]}
         {[ for token in tokens ]}

--- a/src/main-renderers/tailwind-variables.pr
+++ b/src/main-renderers/tailwind-variables.pr
@@ -10,6 +10,7 @@ module.exports = {
                     {[ for token in tokens ]}
                         {[ let tokenName = cleanString(token.name) /]}
                         '{{ ((tokenName === "main") ? "DEFAULT" : tokenName) }}': '{[ inject "rendered-color" context token.value /]}', {[ inject "rendered-description" context token /]}
+                    
                     {[/]}
                 },
             {[/]}


### PR DESCRIPTION
👋 

This is a bit of a bigger PR since I had to modify the helpers a bit. The aim is to solve these 2 issues we ran into

1.  Parent groups that contain only other groups would get outputted as an empty object
2. The name of the group in the tailwind variables will reflect only the first parent group and ignore any further parents 


Supernova:
<img width="332" alt="image" src="https://github.com/torresf/exporter-tailwind/assets/5834683/e7220f2e-760c-49fe-bff9-05b5838a4dee">

Output:
<img width="282" alt="Screenshot 2023-07-17 at 14 42 51" src="https://github.com/torresf/exporter-tailwind/assets/5834683/37af8dda-89e6-4551-bf84-fd1400ac8d0f">

Fix:
<img width="275" alt="Screenshot 2023-07-17 at 14 56 02" src="https://github.com/torresf/exporter-tailwind/assets/5834683/21d1fe5f-6c72-47fe-9d4f-f15011891405">




